### PR TITLE
Update DList.java

### DIFF
--- a/src/DList.java
+++ b/src/DList.java
@@ -129,7 +129,7 @@ public class DList<T extends Comparable<T>> implements IList<T>, Cloneable {
 			if(iterator2.data.compareTo(elem.data) == 0){
 				T data = iterator2.data;
 				iterator1.next = iterator2.next;
-				iterator2.prev = iterator1;
+				iterator2.next.prev = iterator1;
 				size--;
 				// garbage collection will do the rest
 				return data;


### PR DESCRIPTION
There was a minor logical error on the remove method. After finding the node we wanted to remove we set iterator1.next = iterator2.next then set iterator2.prev = iterator1 which is logical wrong since we just remove the node a iterator2. So we sould instead set iterator2.next.prev = iterator1 for proper removal.